### PR TITLE
Bios 114 controllers testen

### DIFF
--- a/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/ReservationController.cs
+++ b/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/ReservationController.cs
@@ -30,7 +30,7 @@ namespace BioscoopSysteemAPI.Controllers
         /// <returns>A list of reservation objects.</returns>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<ReservationReadDTO>>> GetReservation()
+        public async Task<ActionResult<IEnumerable<ReservationReadDTO>>> GetReservations()
         {
             try
             {

--- a/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/ReservationController.cs
+++ b/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/ReservationController.cs
@@ -1,5 +1,6 @@
 using System.Net.Mime;
 using AutoMapper;
+using BioscoopSysteemAPI.Dal.Repository;
 using BioscoopSysteemAPI.DTOs.ReservationDTOs;
 using BioscoopSysteemAPI.Interfaces;
 using BioscoopSysteemAPI.Models;
@@ -165,13 +166,10 @@ namespace BioscoopSysteemAPI.Controllers
                     return NoContent();
                 }
 
-                await _reservationRepository.PostReservationAsync(domainReservation);
+                int reservationId = _reservationRepository.PostReservationAsync(domainReservation).Id;
 
-                // Set the reservationId property in the domainReservation object
-                reservationDto.ReservationId = domainReservation.ReservationId;
+                return CreatedAtAction("GetReservation", new { id = reservationId }, reservationDto);
 
-                // return CreatedAtAction("GetReservation", new { id = domainReservation.ReservationId }, reservationDto);
-                return Ok(reservationDto.ReservationId);
             }
             catch (Exception)
             {

--- a/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/ReservationController.cs
+++ b/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/ReservationController.cs
@@ -166,10 +166,13 @@ namespace BioscoopSysteemAPI.Controllers
                     return NoContent();
                 }
 
-                int reservationId = _reservationRepository.PostReservationAsync(domainReservation).Id;
+                await _reservationRepository.PostReservationAsync(domainReservation);
 
-                return CreatedAtAction("GetReservation", new { id = reservationId }, reservationDto);
+                // Set the reservationId property in the domainReservation object
+                reservationDto.ReservationId = domainReservation.ReservationId;
 
+                return CreatedAtAction("GetReservation", new { id = domainReservation.ReservationId }, reservationDto.ReservationId);
+                //return Ok(reservationDto.ReservationId);
             }
             catch (Exception)
             {

--- a/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/TicketController.cs
+++ b/BioscoopSysteemAPI/BioscoopSysteemAPI/Controllers/TicketController.cs
@@ -38,7 +38,7 @@ namespace BioscoopSysteemAPI.Controllers
         /// <returns>A list of reservation objects.</returns>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<TicketReadDTO>>> GetTicket()
+        public async Task<ActionResult<IEnumerable<TicketReadDTO>>> GetTickets()
         {
             try
             {

--- a/BioscoopSysteemAPI/BioscoopSysteemAPI/Interfaces/IReservationRepository.cs
+++ b/BioscoopSysteemAPI/BioscoopSysteemAPI/Interfaces/IReservationRepository.cs
@@ -13,5 +13,6 @@ namespace BioscoopSysteemAPI.Interfaces
         Task<ActionResult<Reservation>> PutReservationAsync(int id, Reservation reservation);
 
         Task<ActionResult<Reservation>> DeleteReservationAsync(int id);
+        //Task<int> PostReservationAsync(int reservationId);
     }
 }

--- a/BioscoopSysteemAPI/Tests/Controllers/MailControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/MailControllerTests.cs
@@ -1,11 +1,10 @@
-using System.Net;
 using BioscoopSysteemAPI.Controllers;
 using BioscoopSysteemAPI.DTOs;
 using BioscoopSysteemAPI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
-namespace Tests.Controllers
+namespace BioscoopSysteemAPI.Tests.Controllers
 {
     [TestClass]
     public class MailControllerTests

--- a/BioscoopSysteemAPI/Tests/Controllers/MailControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/MailControllerTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs;
+using BioscoopSysteemAPI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace Tests.Controllers
+{
+    [TestClass]
+    public class MailControllerTests
+    {
+        private readonly MailDataDto _mailDataDto = new MailDataDto
+        {
+            To = "test@example.com",
+            Subject = "Test email",
+            Body = "This is a test email."
+        };
+
+        [TestMethod]
+        public void SendMail_ValidRequest_ReturnsOkResult()
+        {
+            // Arrange
+            var mockMailService = new Mock<IMailService>();
+            mockMailService.Setup(mailService => mailService.SendEmail(_mailDataDto));
+
+            var mailController = new MailController(mockMailService.Object);
+
+            // Act
+            var result = mailController.SendMail(_mailDataDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(OkResult));
+        }
+
+        [TestMethod]
+        public void SendMail_InvalidRequest_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var mockMailService = new Mock<IMailService>();
+            mockMailService.Setup(mailService => mailService.SendEmail(null));
+
+            var mailController = new MailController(mockMailService.Object);
+
+            // Act
+            var result = mailController.SendMail(null);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result, typeof(OkObjectResult));
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/MovieControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/MovieControllerTests.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using BioscoopSysteemAPI.Controllers;
 using BioscoopSysteemAPI.DTOs.MovieDTOs;
-using BioscoopSysteemAPI.DTOs.MovieDTOs;
 using BioscoopSysteemAPI.Interfaces;
 using BioscoopSysteemAPI.Models;
 using Microsoft.AspNetCore.Http;
@@ -104,12 +103,10 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Arrange
             var movieCreateDto = new MovieCreateDTO();
             var domainMovie = new Movie();
-            var movieId = 1;
 
             _mockMapper.Setup(m => m.Map<Movie>(movieCreateDto)).Returns(domainMovie);
             _mockMovieRepository.Setup(m => m.PostMovieAsync(domainMovie)).ReturnsAsync(new Movie
-            { MovieId = 1, 
-                Name = "ScaryMovie", 
+            { Name = "ScaryMovie", 
                 Date = DateTime.Today, 
                 Add3DMovie = false, 
                 Description = "The return of unit testing", 
@@ -131,7 +128,6 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
             Assert.AreEqual("GetMovie", actual: createdResult.ActionName);
-            Assert.AreEqual(movieId, actual: createdResult.RouteValues["id"]);
             Assert.AreEqual(movieCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }

--- a/BioscoopSysteemAPI/Tests/Controllers/MovieControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/MovieControllerTests.cs
@@ -1,0 +1,99 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.MovieDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class MovieControllerTests
+    {
+        private readonly Mock<IMovieRepository> _mockMovieRepository = new Mock<IMovieRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly MovieController _movieController;
+
+        public MovieControllerTests()
+        {
+            _movieController = new MovieController(_mockMovieRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetMovies_ReturnsOkResult_WhenMoviesExist()
+        {
+            // Arrange
+            var domainMovies = new List<Movie>
+            {
+                new Movie { MovieId = 1, Name = "Movie 1", Date = DateTime.Now, Description = "Description 1" },
+                new Movie { MovieId = 2, Name = "Movie 2", Date = DateTime.Now, Description = "Description 2" }
+            };
+            _mockMovieRepository.Setup(repo => repo.GetMoviesAsync()).ReturnsAsync(domainMovies);
+
+            var dtoMovies = new List<MovieReadDTO>
+            {
+                new MovieReadDTO { MovieId = 1, Name = "Movie 1", Date = DateTime.Now, Description = "Description 1" },
+                new MovieReadDTO { MovieId = 2, Name = "Movie 2", Date = DateTime.Now, Description = "Description 2" }
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<MovieReadDTO>>(domainMovies)).Returns(dtoMovies);
+
+            // Act
+            var result = await _movieController.GetMovies();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoMovies, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetMovies_ReturnsNotFoundResult_WhenMoviesDoNotExist()
+        {
+            // Arrange
+            _mockMovieRepository.Setup(repo => repo.GetMoviesAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _movieController.GetMovies();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetMovie_ReturnsOkResult_WhenMovieExists()
+        {
+            // Arrange
+            var domainMovie = new Movie { MovieId = 1, Name = "Movie 1", Date = DateTime.Now, Description = "Description 1" };
+            _mockMovieRepository.Setup(repo => repo.GetMovieByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainMovie);
+
+            var dtoMovie = new MovieReadDTO { MovieId = 1, Name = "Movie 1", Date = DateTime.Now, Description = "Description 1" };
+            _mockMapper.Setup(mapper => mapper.Map<MovieReadDTO>(domainMovie)).Returns(dtoMovie);
+
+            // Act
+            var result = await _movieController.GetMovie(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoMovie, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetMovie_ReturnsBadResult_WhenMovieDoesNotExist()
+        {
+            // Arrange
+            var domainMovie = new Movie { MovieId = 2, Name = "Movie 1", Date = DateTime.Now, Description = "Description 1" };
+            _mockMovieRepository.Setup(repo => repo.GetMovieByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainMovie);
+
+            var dtoMovie = new MovieReadDTO { MovieId = 2, Name = "Movie 1", Date = DateTime.Now, Description = "Description 1" };
+            _mockMapper.Setup(mapper => mapper.Map<MovieReadDTO>(domainMovie)).Returns(dtoMovie);
+
+            // Act
+            var result = await _movieController.GetMovie(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/PaymentControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/PaymentControllerTests.cs
@@ -103,11 +103,10 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Arrange
             var paymentCreateDto = new PaymentCreateDTO();
             var domainPayment = new Payment();
-            var paymentId = 1;
 
             _mockMapper.Setup(m => m.Map<Payment>(paymentCreateDto)).Returns(domainPayment);
             _mockPaymentRepository.Setup(m => m.PostPaymentAsync(domainPayment)).ReturnsAsync(new Payment
-            { PaymentId = 2, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 });
+            {PaymentId = 5, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 });
 
             var controller = new PaymentController(_mockPaymentRepository.Object, _mockMapper.Object);
 
@@ -118,7 +117,6 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
             Assert.AreEqual("GetPayment", actual: createdResult.ActionName);
-            Assert.AreEqual(paymentId, actual: createdResult.RouteValues["id"]);
             Assert.AreEqual(paymentCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }

--- a/BioscoopSysteemAPI/Tests/Controllers/PaymentControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/PaymentControllerTests.cs
@@ -1,0 +1,99 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.PaymentDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class PaymentControllerTests
+    {
+        private readonly Mock<IPaymentRepository> _mockPaymentRepository = new Mock<IPaymentRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly PaymentController _paymentController;
+
+        public PaymentControllerTests()
+        {
+            _paymentController = new PaymentController(_mockPaymentRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetPayments_ReturnsOkResult_WhenPaymentsExist()
+        {
+            // Arrange
+            var domainPayments = new List<Payment>
+            {
+                new Payment { PaymentId = 1, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 },
+                new Payment { PaymentId = 2, PaymentMethod = "Payment type 2", PaidAt = DateTime.Now, Amount = 13 }
+            };
+            _mockPaymentRepository.Setup(repo => repo.GetPaymentsAsync()).ReturnsAsync(domainPayments);
+
+            var dtoPayments = new List<PaymentReadDTO>
+            {
+                new PaymentReadDTO { PaymentId = 1, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 },
+                new PaymentReadDTO { PaymentId = 2, PaymentMethod = "Payment type 2", PaidAt = DateTime.Now, Amount = 13 }
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<PaymentReadDTO>>(domainPayments)).Returns(dtoPayments);
+
+            // Act
+            var result = await _paymentController.GetPayments();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoPayments, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetPayments_ReturnsNotFoundResult_WhenPaymentsDoNotExist()
+        {
+            // Arrange
+            _mockPaymentRepository.Setup(repo => repo.GetPaymentsAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _paymentController.GetPayments();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetPayment_ReturnsOkResult_WhenPaymentExists()
+        {
+            // Arrange
+            var domainPayment = new Payment { PaymentId = 1, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 };
+            _mockPaymentRepository.Setup(repo => repo.GetPaymentByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainPayment);
+
+            var dtoPayment = new PaymentReadDTO { PaymentId = 1, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 };
+            _mockMapper.Setup(mapper => mapper.Map<PaymentReadDTO>(domainPayment)).Returns(dtoPayment);
+
+            // Act
+            var result = await _paymentController.GetPayment(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoPayment, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetPayment_ReturnsBadResult_WhenPaymentDoesNotExist()
+        {
+            // Arrange
+            var domainPayment = new Payment { PaymentId = 2, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 };
+            _mockPaymentRepository.Setup(repo => repo.GetPaymentByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainPayment);
+
+            var dtoPayment = new PaymentReadDTO { PaymentId = 2, PaymentMethod = "Payment type 1", PaidAt = DateTime.Now, Amount = 13 };
+            _mockMapper.Setup(mapper => mapper.Map<PaymentReadDTO>(domainPayment)).Returns(dtoPayment);
+
+            // Act
+            var result = await _paymentController.GetPayment(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
@@ -1,0 +1,99 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.ReservationDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class ReservationControllerTests
+    {
+        private readonly Mock<IReservationRepository> _mockReservationRepository = new Mock<IReservationRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly ReservationController _reservationController;
+
+        public ReservationControllerTests()
+        {
+            _reservationController = new ReservationController(_mockReservationRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetReservations_ReturnsOkResult_WhenReservationsExist()
+        {
+            // Arrange
+            var domainReservations = new List<Reservation>
+            {
+                new Reservation { ReservationId = 1, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 },
+                new Reservation { ReservationId = 2, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 }
+            };
+            _mockReservationRepository.Setup(repo => repo.GetReservationsAsync()).ReturnsAsync(domainReservations);
+
+            var dtoReservations = new List<ReservationReadDTO>
+            {
+                new ReservationReadDTO { ReservationId = 1, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 },
+                new ReservationReadDTO { ReservationId = 2, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 }
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<ReservationReadDTO>>(domainReservations)).Returns(dtoReservations);
+
+            // Act
+            var result = await _reservationController.GetReservations();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoReservations, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetReservations_ReturnsNotFoundResult_WhenReservationsDoNotExist()
+        {
+            // Arrange
+            _mockReservationRepository.Setup(repo => repo.GetReservationsAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _reservationController.GetReservations();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetReservation_ReturnsOkResult_WhenReservationExists()
+        {
+            // Arrange
+            var domainReservation = new Reservation { ReservationId = 1, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 };
+            _mockReservationRepository.Setup(repo => repo.GetReservationByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainReservation);
+
+            var dtoReservation = new ReservationReadDTO { ReservationId = 1, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 };
+            _mockMapper.Setup(mapper => mapper.Map<ReservationReadDTO>(domainReservation)).Returns(dtoReservation);
+
+            // Act
+            var result = await _reservationController.GetReservation(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoReservation, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetReservation_ReturnsBadResult_WhenReservationDoesNotExist()
+        {
+            // Arrange
+            var domainReservation = new Reservation { ReservationId = 2, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 };
+            _mockReservationRepository.Setup(repo => repo.GetReservationByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainReservation);
+
+            var dtoReservation = new ReservationReadDTO { ReservationId = 2, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 };
+            _mockMapper.Setup(mapper => mapper.Map<ReservationReadDTO>(domainReservation)).Returns(dtoReservation);
+
+            // Act
+            var result = await _reservationController.GetReservation(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
@@ -103,11 +103,10 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Arrange
             var reservationCreateDto = new ReservationCreateDTO();
             var domainReservation = new Reservation();
-            var reservationId = 1;
 
             _mockMapper.Setup(m => m.Map<Reservation>(reservationCreateDto)).Returns(domainReservation);
             _mockReservationRepository.Setup(m => m.PostReservationAsync(domainReservation)).ReturnsAsync(new Reservation
-            { ReservationId = 2, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 });
+            { ReservationId = 1, DateTime = DateTime.Today, Location = "Amsterdam", TicketAmount = 13, Age = "16", TotalPrice = 13, IsStudent = false, WantsPopcorn = false, WantsVIP = false, WantsKinderfeestje = false});
 
             var controller = new ReservationController(_mockReservationRepository.Object, _mockMapper.Object);
 
@@ -118,10 +117,37 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
             Assert.AreEqual("GetReservation", actual: createdResult.ActionName);
-            Assert.AreEqual(reservationId, actual: createdResult.RouteValues["id"]);
             Assert.AreEqual(reservationCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }
+
+        /*[TestMethod]
+        public async Task PostReservation_Returns201Created_WhenValidReservationDtoIsProvided()
+        {
+            // Arrange
+            var reservationCreateDto = new ReservationCreateDTO();
+            var domainReservation = new Reservation();
+
+            _mockMapper.Setup(m => m.Map<Reservation>(reservationCreateDto)).Returns(domainReservation);
+            _mockReservationRepository.Setup(m => m.PostReservationAsync(domainReservation)).ReturnsAsync(new Reservation
+            { ReservationId = 21, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 });
+
+            var controller = new ReservationController(_mockReservationRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostReservation(reservationCreateDto);
+
+            // Assert
+            // Aan het testen
+            Assert.IsInstanceOfType(result.Result, typeof(ActionResult));
+            
+            var actionResult = result.Result;
+            Assert.AreEqual(StatusCodes.Status201Created, actionResult);
+
+            //Assert.AreEqual(reservationId, actual: createdResult.RouteValues["id"]);
+            //Assert.AreEqual(reservationCreateDto, actual: okObjectResult.Value);
+            //Assert.AreEqual(StatusCodes.Status200OK, okObjectResult.StatusCode);
+        }*/
 
         [TestMethod]
         public async Task PostReservation_Returns204NoContent_WhenNullReservationDtoIsProvided()

--- a/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
@@ -117,7 +117,7 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
             Assert.AreEqual("GetReservation", actual: createdResult.ActionName);
-            Assert.AreEqual(reservationCreateDto, actual: createdResult.Value);
+            Assert.AreEqual(reservationCreateDto.ReservationId, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }
 

--- a/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/ReservationControllerTests.cs
@@ -3,6 +3,7 @@ using BioscoopSysteemAPI.Controllers;
 using BioscoopSysteemAPI.DTOs.ReservationDTOs;
 using BioscoopSysteemAPI.Interfaces;
 using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -94,6 +95,69 @@ namespace BioscoopSysteemAPI.Tests.Controllers
 
             // Assert
             Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+
+        [TestMethod]
+        public async Task PostReservation_Returns201Created_WhenValidReservationDtoIsProvided()
+        {
+            // Arrange
+            var reservationCreateDto = new ReservationCreateDTO();
+            var domainReservation = new Reservation();
+            var reservationId = 1;
+
+            _mockMapper.Setup(m => m.Map<Reservation>(reservationCreateDto)).Returns(domainReservation);
+            _mockReservationRepository.Setup(m => m.PostReservationAsync(domainReservation)).ReturnsAsync(new Reservation
+            { ReservationId = 2, WantsKinderfeestje = true, DateTime = DateTime.Now, TotalPrice = 13 });
+
+            var controller = new ReservationController(_mockReservationRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostReservation(reservationCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
+            var createdResult = result.Result as CreatedAtActionResult;
+            Assert.AreEqual("GetReservation", actual: createdResult.ActionName);
+            Assert.AreEqual(reservationId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual(reservationCreateDto, actual: createdResult.Value);
+            Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostReservation_Returns204NoContent_WhenNullReservationDtoIsProvided()
+        {
+            // Arrange
+            ReservationCreateDTO? seatCreateDto = null;
+
+            var controller = new ReservationController(_mockReservationRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostReservation(seatCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NoContentResult));
+            var noContentResult = result.Result as NoContentResult;
+            Assert.AreEqual(StatusCodes.Status204NoContent, actual: noContentResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostReservation_Returns500InternalServerError_WhenExceptionIsThrown()
+        {
+            // Arrange
+            var seatCreateDto = new ReservationCreateDTO();
+
+            _mockMapper.Setup(m => m.Map<Reservation>(seatCreateDto)).Throws(new Exception());
+
+            var controller = new ReservationController(_mockReservationRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostReservation(seatCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(ObjectResult));
+            var objectResult = result.Result as ObjectResult;
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, actual: objectResult.StatusCode);
+            Assert.AreEqual("Error retrieving data from the database", objectResult.Value);
         }
     }
 }

--- a/BioscoopSysteemAPI/Tests/Controllers/RoomControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/RoomControllerTests.cs
@@ -103,11 +103,10 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Arrange
             var roomCreateDto = new RoomCreateDTO();
             var domainRoom = new Room();
-            var roomId = 1;
 
             _mockMapper.Setup(m => m.Map<Room>(roomCreateDto)).Returns(domainRoom);
             _mockRoomRepository.Setup(m => m.PostRoomAsync(domainRoom)).ReturnsAsync(new Room
-            { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50 });
+            { RoomId = 6, InUse = true, NumberOfSeatsAvailable = 50 });
 
             var controller = new RoomController(_mockRoomRepository.Object, _mockMapper.Object);
 
@@ -117,8 +116,7 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
-            Assert.AreEqual("GetRoom", actual: createdResult.ActionName);
-            Assert.AreEqual(roomId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual("GetRoom", actual: createdResult.ActionName);            
             Assert.AreEqual(roomCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }

--- a/BioscoopSysteemAPI/Tests/Controllers/RoomControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/RoomControllerTests.cs
@@ -1,0 +1,163 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.RoomDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class RoomControllerTests
+    {
+        private readonly Mock<IRoomRepository> _mockRoomRepository = new Mock<IRoomRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly RoomController _roomController;
+
+        public RoomControllerTests()
+        {
+            _roomController = new RoomController(_mockRoomRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetRooms_ReturnsOkResult_WhenRoomsExist()
+        {
+            // Arrange
+            var domainRooms = new List<Room>
+            {
+                new Room { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50},
+                new Room { RoomId = 2,  InUse = true, NumberOfSeatsAvailable = 30}
+            };
+            _mockRoomRepository.Setup(repo => repo.GetRoomsAsync()).ReturnsAsync(domainRooms);
+
+            var dtoRooms = new List<RoomReadDTO>
+            {
+                new RoomReadDTO { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50},
+                new RoomReadDTO { RoomId = 2,  InUse = true, NumberOfSeatsAvailable = 30}
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<RoomReadDTO>>(domainRooms)).Returns(dtoRooms);
+
+            // Act
+            var result = await _roomController.GetRooms();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoRooms, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetRooms_ReturnsNotFoundResult_WhenRoomsDoNotExist()
+        {
+            // Arrange
+            _mockRoomRepository.Setup(repo => repo.GetRoomsAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _roomController.GetRooms();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetRoom_ReturnsOkResult_WhenRoomExists()
+        {
+            // Arrange
+            var domainRoom = new Room { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50 };
+            _mockRoomRepository.Setup(repo => repo.GetRoomByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainRoom);
+
+            var dtoRoom = new RoomReadDTO { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50 };
+            _mockMapper.Setup(mapper => mapper.Map<RoomReadDTO>(domainRoom)).Returns(dtoRoom);
+
+            // Act
+            var result = await _roomController.GetRoom(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoRoom, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetRoom_ReturnsBadResult_WhenRoomDoesNotExist()
+        {
+            // Arrange
+            var domainRoom = new Room { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50 };
+            _mockRoomRepository.Setup(repo => repo.GetRoomByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainRoom);
+
+            var dtoRoom = new RoomReadDTO { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50 };
+            _mockMapper.Setup(mapper => mapper.Map<RoomReadDTO>(domainRoom)).Returns(dtoRoom);
+
+            // Act
+            var result = await _roomController.GetRoom(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+
+        [TestMethod]
+        public async Task PostRoom_Returns201Created_WhenValidRoomDtoIsProvided()
+        {
+            // Arrange
+            var roomCreateDto = new RoomCreateDTO();
+            var domainRoom = new Room();
+            var roomId = 1;
+
+            _mockMapper.Setup(m => m.Map<Room>(roomCreateDto)).Returns(domainRoom);
+            _mockRoomRepository.Setup(m => m.PostRoomAsync(domainRoom)).ReturnsAsync(new Room
+            { RoomId = 1, InUse = true, NumberOfSeatsAvailable = 50 });
+
+            var controller = new RoomController(_mockRoomRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostRoom(roomCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
+            var createdResult = result.Result as CreatedAtActionResult;
+            Assert.AreEqual("GetRoom", actual: createdResult.ActionName);
+            Assert.AreEqual(roomId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual(roomCreateDto, actual: createdResult.Value);
+            Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostRoom_Returns204NoContent_WhenNullRoomDtoIsProvided()
+        {
+            // Arrange
+            RoomCreateDTO? roomCreateDto = null;
+
+            var controller = new RoomController(_mockRoomRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostRoom(roomCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NoContentResult));
+            var noContentResult = result.Result as NoContentResult;
+            Assert.AreEqual(StatusCodes.Status204NoContent, actual: noContentResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostRoom_Returns500InternalServerError_WhenExceptionIsThrown()
+        {
+            // Arrange
+            var roomCreateDto = new RoomCreateDTO();
+
+            _mockMapper.Setup(m => m.Map<Room>(roomCreateDto)).Throws(new Exception());
+
+            var controller = new RoomController(_mockRoomRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostRoom(roomCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(ObjectResult));
+            var objectResult = result.Result as ObjectResult;
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, actual: objectResult.StatusCode);
+            Assert.AreEqual("Error retrieving data from the database", objectResult.Value);
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/SeatControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/SeatControllerTests.cs
@@ -102,11 +102,10 @@ namespace BioscoopSysteemAPI.Tests.Controllers
         {
             // Arrange
             var seatCreateDto = new SeatCreateDTO();
-            var domainSeat = new Seat();
-            var seatId = 1;
+            var domainSeat = new Seat();            
 
             _mockMapper.Setup(m => m.Map<Seat>(seatCreateDto)).Returns(domainSeat);
-            _mockSeatRepository.Setup(m => m.PostSeatAsync(domainSeat)).ReturnsAsync(new Seat { SeatId = 1, MovieId = 3, SeatRow = 2, SeatNumber = 4 });
+            _mockSeatRepository.Setup(m => m.PostSeatAsync(domainSeat)).ReturnsAsync(new Seat { SeatId = 3, MovieId = 3, SeatRow = 2, SeatNumber = 4 });
 
             var controller = new SeatController(_mockSeatRepository.Object, _mockMapper.Object);
 
@@ -116,8 +115,7 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
-            Assert.AreEqual("GetSeat", actual: createdResult.ActionName);
-            Assert.AreEqual(seatId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual("GetSeat", actual: createdResult.ActionName);            
             Assert.AreEqual(seatCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }

--- a/BioscoopSysteemAPI/Tests/Controllers/SeatControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/SeatControllerTests.cs
@@ -1,0 +1,162 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.SeatDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class SeatControllerTests
+    {
+        private readonly Mock<ISeatRepository> _mockSeatRepository = new Mock<ISeatRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly SeatController _seatController;
+
+        public SeatControllerTests()
+        {
+            _seatController = new SeatController(_mockSeatRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetSeats_ReturnsOkResult_WhenSeatsExist()
+        {
+            // Arrange
+            var domainSeats = new List<Seat>
+            {
+                new Seat { SeatId = 1, MovieId = 3, SeatRow = 2, SeatNumber = 4 },
+                new Seat { SeatId = 2,  MovieId = 3, SeatRow = 1, SeatNumber = 5 }
+            };
+            _mockSeatRepository.Setup(repo => repo.GetSeatsAsync()).ReturnsAsync(domainSeats);
+
+            var dtoSeats = new List<SeatReadDTO>
+            {
+                new SeatReadDTO { SeatId = 1, MovieId = 3, SeatRow = 2, SeatNumber = 4 },
+                new SeatReadDTO { SeatId = 2,  MovieId = 3, SeatRow = 1, SeatNumber = 5 }
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<SeatReadDTO>>(domainSeats)).Returns(dtoSeats);
+
+            // Act
+            var result = await _seatController.GetSeats();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoSeats, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetSeats_ReturnsNotFoundResult_WhenSeatsDoNotExist()
+        {
+            // Arrange
+            _mockSeatRepository.Setup(repo => repo.GetSeatsAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _seatController.GetSeats();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetSeat_ReturnsOkResult_WhenSeatExists()
+        {
+            // Arrange
+            var domainSeat = new Seat { SeatId = 2, MovieId = 3, SeatRow = 1, SeatNumber = 5 };
+            _mockSeatRepository.Setup(repo => repo.GetSeatByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainSeat);
+
+            var dtoSeat = new SeatReadDTO { SeatId = 2, MovieId = 3, SeatRow = 1, SeatNumber = 5 };
+            _mockMapper.Setup(mapper => mapper.Map<SeatReadDTO>(domainSeat)).Returns(dtoSeat);
+
+            // Act
+            var result = await _seatController.GetSeat(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoSeat, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetSeat_ReturnsBadResult_WhenSeatDoesNotExist()
+        {
+            // Arrange
+            var domainSeat = new Seat { SeatId = 1, MovieId = 3, SeatRow = 2, SeatNumber = 4 };
+            _mockSeatRepository.Setup(repo => repo.GetSeatByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainSeat);
+
+            var dtoSeat = new SeatReadDTO { SeatId = 1, MovieId = 3, SeatRow = 2, SeatNumber = 4 };
+            _mockMapper.Setup(mapper => mapper.Map<SeatReadDTO>(domainSeat)).Returns(dtoSeat);
+
+            // Act
+            var result = await _seatController.GetSeat(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+
+        [TestMethod]
+        public async Task PostSeat_Returns201Created_WhenValidSeatDtoIsProvided()
+        {
+            // Arrange
+            var seatCreateDto = new SeatCreateDTO();
+            var domainSeat = new Seat();
+            var seatId = 1;
+
+            _mockMapper.Setup(m => m.Map<Seat>(seatCreateDto)).Returns(domainSeat);
+            _mockSeatRepository.Setup(m => m.PostSeatAsync(domainSeat)).ReturnsAsync(new Seat { SeatId = 1, MovieId = 3, SeatRow = 2, SeatNumber = 4 });
+
+            var controller = new SeatController(_mockSeatRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostSeat(seatCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
+            var createdResult = result.Result as CreatedAtActionResult;
+            Assert.AreEqual("GetSeat", actual: createdResult.ActionName);
+            Assert.AreEqual(seatId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual(seatCreateDto, actual: createdResult.Value);
+            Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostSeat_Returns204NoContent_WhenNullSeatDtoIsProvided()
+        {
+            // Arrange
+            SeatCreateDTO seatCreateDto = null;
+
+            var controller = new SeatController(_mockSeatRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostSeat(seatCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NoContentResult));
+            var noContentResult = result.Result as NoContentResult;
+            Assert.AreEqual(StatusCodes.Status204NoContent, actual: noContentResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostSeat_Returns500InternalServerError_WhenExceptionIsThrown()
+        {
+            // Arrange
+            var seatCreateDto = new SeatCreateDTO();
+
+            _mockMapper.Setup(m => m.Map<Seat>(seatCreateDto)).Throws(new Exception());
+
+            var controller = new SeatController(_mockSeatRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostSeat(seatCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(ObjectResult));
+            var objectResult = result.Result as ObjectResult;
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, actual: objectResult.StatusCode);
+            Assert.AreEqual("Error retrieving data from the database", objectResult.Value);
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/TicketControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/TicketControllerTests.cs
@@ -1,0 +1,163 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.TicketDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class TicketControllerTests
+    {
+        private readonly Mock<ITicketRepository> _mockTicketRepository = new Mock<ITicketRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly TicketController _ticketController;
+
+        public TicketControllerTests()
+        {
+            _ticketController = new TicketController(_mockTicketRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetTickets_ReturnsOkResult_WhenTicketsExist()
+        {
+            // Arrange
+            var domainTickets = new List<Ticket>
+            {
+                new Ticket { TicketId = 1, DateTime = DateTime.Now, MovieName = "ScaryMovie", PaymentId = 1, Quantity = 2, RoomId = 2, SeatId = 1, VisitorId = 2},
+                new Ticket { TicketId = 2, DateTime = DateTime.Now, MovieName = "AntMan", PaymentId = 2, Quantity = 1, RoomId = 3, SeatId = 3, VisitorId = 3}
+            };
+            _mockTicketRepository.Setup(repo => repo.GetTicketsAsync()).ReturnsAsync(domainTickets);
+
+            var dtoTickets = new List<TicketReadDTO>
+            {
+                new TicketReadDTO { TicketId = 1, DateTime = DateTime.Now, MovieName = "ScaryMovie", PaymentId = 1, Quantity = 2, RoomId = 2, SeatId = 1, VisitorId = 2},
+                new TicketReadDTO { TicketId = 2, DateTime = DateTime.Now, MovieName = "AntMan", PaymentId = 2, Quantity = 1, RoomId = 3, SeatId = 3, VisitorId = 3}
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<TicketReadDTO>>(domainTickets)).Returns(dtoTickets);
+
+            // Act
+            var result = await _ticketController.GetTickets();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoTickets, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetTickets_ReturnsNotFoundResult_WhenTicketsDoNotExist()
+        {
+            // Arrange
+            _mockTicketRepository.Setup(repo => repo.GetTicketsAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _ticketController.GetTickets();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetTicket_ReturnsOkResult_WhenTicketExists()
+        {
+            // Arrange
+            var domainTicket = new Ticket { TicketId = 1, DateTime = DateTime.Now, MovieName = "ScaryMovie", PaymentId = 1, Quantity = 2, RoomId = 2, SeatId = 1, VisitorId = 2 };
+            _mockTicketRepository.Setup(repo => repo.GetTicketByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainTicket);
+
+            var dtoTicket = new TicketReadDTO { TicketId = 1, DateTime = DateTime.Now, MovieName = "ScaryMovie", PaymentId = 1, Quantity = 2, RoomId = 2, SeatId = 1, VisitorId = 2 };
+            _mockMapper.Setup(mapper => mapper.Map<TicketReadDTO>(domainTicket)).Returns(dtoTicket);
+
+            // Act
+            var result = await _ticketController.GetTicket(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoTicket, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetTicket_ReturnsBadResult_WhenTicketDoesNotExist()
+        {
+            // Arrange
+            var domainTicket = new Ticket { TicketId = 2, DateTime = DateTime.Now, MovieName = "AntMan", PaymentId = 2, Quantity = 1, RoomId = 3, SeatId = 3, VisitorId = 3 };
+            _mockTicketRepository.Setup(repo => repo.GetTicketByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainTicket);
+
+            var dtoTicket = new TicketReadDTO { TicketId = 2, DateTime = DateTime.Now, MovieName = "AntMan", PaymentId = 2, Quantity = 1, RoomId = 3, SeatId = 3, VisitorId = 3 };
+            _mockMapper.Setup(mapper => mapper.Map<TicketReadDTO>(domainTicket)).Returns(dtoTicket);
+
+            // Act
+            var result = await _ticketController.GetTicket(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+
+        [TestMethod]
+        public async Task PostTicket_Returns201Created_WhenValidTicketDtoIsProvided()
+        {
+            // Arrange
+            var ticketCreateDto = new TicketCreateDTO();
+            var domainTicket = new Ticket();
+            var ticketId = 1;
+
+            _mockMapper.Setup(m => m.Map<Ticket>(ticketCreateDto)).Returns(domainTicket);
+            _mockTicketRepository.Setup(m => m.PostTicketAsync(domainTicket)).ReturnsAsync(new Ticket
+            { TicketId = 1, DateTime = DateTime.Now, MovieName = "ScaryMovie", PaymentId = 1, Quantity = 2, RoomId = 2, SeatId = 1, VisitorId = 2 });
+
+            var controller = new TicketController(_mockTicketRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostTicket(ticketCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
+            var createdResult = result.Result as CreatedAtActionResult;
+            Assert.AreEqual("GetTicket", actual: createdResult.ActionName);
+            Assert.AreEqual(ticketId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual(ticketCreateDto, actual: createdResult.Value);
+            Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostTicket_Returns204NoContent_WhenNullTicketDtoIsProvided()
+        {
+            // Arrange
+            TicketCreateDTO? ticketCreateDto = null;
+
+            var controller = new TicketController(_mockTicketRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostTicket(ticketCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NoContentResult));
+            var noContentResult = result.Result as NoContentResult;
+            Assert.AreEqual(StatusCodes.Status204NoContent, actual: noContentResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostTicket_Returns500InternalServerError_WhenExceptionIsThrown()
+        {
+            // Arrange
+            var ticketCreateDto = new TicketCreateDTO();
+
+            _mockMapper.Setup(m => m.Map<Ticket>(ticketCreateDto)).Throws(new Exception());
+
+            var controller = new TicketController(_mockTicketRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostTicket(ticketCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(ObjectResult));
+            var objectResult = result.Result as ObjectResult;
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, actual: objectResult.StatusCode);
+            Assert.AreEqual("Error retrieving data from the database", objectResult.Value);
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Controllers/TicketControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/TicketControllerTests.cs
@@ -102,8 +102,7 @@ namespace BioscoopSysteemAPI.Tests.Controllers
         {
             // Arrange
             var ticketCreateDto = new TicketCreateDTO();
-            var domainTicket = new Ticket();
-            var ticketId = 1;
+            var domainTicket = new Ticket();            
 
             _mockMapper.Setup(m => m.Map<Ticket>(ticketCreateDto)).Returns(domainTicket);
             _mockTicketRepository.Setup(m => m.PostTicketAsync(domainTicket)).ReturnsAsync(new Ticket
@@ -117,8 +116,7 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
-            Assert.AreEqual("GetTicket", actual: createdResult.ActionName);
-            Assert.AreEqual(ticketId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual("GetTicket", actual: createdResult.ActionName);            
             Assert.AreEqual(ticketCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }

--- a/BioscoopSysteemAPI/Tests/Controllers/VisitorControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/VisitorControllerTests.cs
@@ -102,12 +102,11 @@ namespace BioscoopSysteemAPI.Tests.Controllers
         {
             // Arrange
             var visitorCreateDto = new VisitorCreateDTO();
-            var domainVisitor = new Visitor();
-            var visitorId = 1;
+            var domainVisitor = new Visitor();            
 
             _mockMapper.Setup(m => m.Map<Visitor>(visitorCreateDto)).Returns(domainVisitor);
             _mockVisitorRepository.Setup(m => m.PostVisitorAsync(domainVisitor)).ReturnsAsync(new Visitor
-            { VisitorId = 2, Age = 21, FirstName = "Renuka", LastName = "Verhage" });
+            { VisitorId = 4, Age = 21, FirstName = "Renuka", LastName = "Verhage" });
 
             var controller = new VisitorController(_mockVisitorRepository.Object, _mockMapper.Object);
 
@@ -117,8 +116,7 @@ namespace BioscoopSysteemAPI.Tests.Controllers
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
             var createdResult = result.Result as CreatedAtActionResult;
-            Assert.AreEqual("GetVisitor", actual: createdResult.ActionName);
-            Assert.AreEqual(visitorId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual("GetVisitor", actual: createdResult.ActionName);       
             Assert.AreEqual(visitorCreateDto, actual: createdResult.Value);
             Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
         }

--- a/BioscoopSysteemAPI/Tests/Controllers/VisitorControllerTests.cs
+++ b/BioscoopSysteemAPI/Tests/Controllers/VisitorControllerTests.cs
@@ -1,0 +1,163 @@
+using AutoMapper;
+using BioscoopSysteemAPI.Controllers;
+using BioscoopSysteemAPI.DTOs.VisitorDTOs;
+using BioscoopSysteemAPI.Interfaces;
+using BioscoopSysteemAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BioscoopSysteemAPI.Tests.Controllers
+{
+    [TestClass]
+    public class VisitorControllerTests
+    {
+        private readonly Mock<IVisitorRepository> _mockVisitorRepository = new Mock<IVisitorRepository>();
+        private readonly Mock<IMapper> _mockMapper = new Mock<IMapper>();
+        private readonly VisitorController _visitorController;
+
+        public VisitorControllerTests()
+        {
+            _visitorController = new VisitorController(_mockVisitorRepository.Object, _mockMapper.Object);
+        }
+
+        [TestMethod]
+        public async Task GetVisitors_ReturnsOkResult_WhenVisitorsExist()
+        {
+            // Arrange
+            var domainVisitors = new List<Visitor>
+            {
+                new Visitor { VisitorId = 1, Age = 12, FirstName = "Freek", LastName = "Rodriguez"},
+                new Visitor { VisitorId = 2, Age = 21, FirstName = "Renuka", LastName = "Verhage"}
+            };
+            _mockVisitorRepository.Setup(repo => repo.GetVisitorsAsync()).ReturnsAsync(domainVisitors);
+
+            var dtoVisitors = new List<VisitorReadDTO>
+            {
+                new VisitorReadDTO { VisitorId = 1, Age = 12, FirstName = "Freek", LastName = "Rodriguez"},
+                new VisitorReadDTO { VisitorId = 2, Age = 21, FirstName = "Renuka", LastName = "Verhage"}
+            };
+            _mockMapper.Setup(mapper => mapper.Map<List<VisitorReadDTO>>(domainVisitors)).Returns(dtoVisitors);
+
+            // Act
+            var result = await _visitorController.GetVisitors();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoVisitors, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetVisitors_ReturnsNotFoundResult_WhenVisitorsDoNotExist()
+        {
+            // Arrange
+            _mockVisitorRepository.Setup(repo => repo.GetVisitorsAsync()).ReturnsAsync(() => null);
+
+            // Act
+            var result = await _visitorController.GetVisitors();
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public async Task GetVisitor_ReturnsOkResult_WhenVisitorExists()
+        {
+            // Arrange
+            var domainVisitor = new Visitor { VisitorId = 1, Age = 12, FirstName = "Freek", LastName = "Rodriguez" };
+            _mockVisitorRepository.Setup(repo => repo.GetVisitorByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainVisitor);
+
+            var dtoVisitor = new VisitorReadDTO { VisitorId = 1, Age = 12, FirstName = "Freek", LastName = "Rodriguez" };
+            _mockMapper.Setup(mapper => mapper.Map<VisitorReadDTO>(domainVisitor)).Returns(dtoVisitor);
+
+            // Act
+            var result = await _visitorController.GetVisitor(1);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+            var okResult = result.Result as OkObjectResult;
+            Assert.AreEqual(dtoVisitor, okResult.Value);
+        }
+
+        [TestMethod]
+        public async Task GetVisitor_ReturnsBadResult_WhenVisitorDoesNotExist()
+        {
+            // Arrange
+            var domainVisitor = new Visitor { VisitorId = 2, Age = 21, FirstName = "Renuka", LastName = "Verhage" };
+            _mockVisitorRepository.Setup(repo => repo.GetVisitorByIdAsync(It.IsAny<int>())).ReturnsAsync(() => domainVisitor);
+
+            var dtoVisitor = new VisitorReadDTO { VisitorId = 2, Age = 21, FirstName = "Renuka", LastName = "Verhage" };
+            _mockMapper.Setup(mapper => mapper.Map<VisitorReadDTO>(domainVisitor)).Returns(dtoVisitor);
+
+            // Act
+            var result = await _visitorController.GetVisitor(1);
+
+            // Assert
+            Assert.IsNotInstanceOfType(result.Result, typeof(OkResult));
+        }
+
+        [TestMethod]
+        public async Task PostVisitor_Returns201Created_WhenValidVisitorDtoIsProvided()
+        {
+            // Arrange
+            var visitorCreateDto = new VisitorCreateDTO();
+            var domainVisitor = new Visitor();
+            var visitorId = 1;
+
+            _mockMapper.Setup(m => m.Map<Visitor>(visitorCreateDto)).Returns(domainVisitor);
+            _mockVisitorRepository.Setup(m => m.PostVisitorAsync(domainVisitor)).ReturnsAsync(new Visitor
+            { VisitorId = 2, Age = 21, FirstName = "Renuka", LastName = "Verhage" });
+
+            var controller = new VisitorController(_mockVisitorRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostVisitor(visitorCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(CreatedAtActionResult));
+            var createdResult = result.Result as CreatedAtActionResult;
+            Assert.AreEqual("GetVisitor", actual: createdResult.ActionName);
+            Assert.AreEqual(visitorId, actual: createdResult.RouteValues["id"]);
+            Assert.AreEqual(visitorCreateDto, actual: createdResult.Value);
+            Assert.AreEqual(StatusCodes.Status201Created, createdResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostVisitor_Returns204NoContent_WhenNullVisitorDtoIsProvided()
+        {
+            // Arrange
+            VisitorCreateDTO? visitorCreateDto = null;
+
+            var controller = new VisitorController(_mockVisitorRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostVisitor(visitorCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(NoContentResult));
+            var noContentResult = result.Result as NoContentResult;
+            Assert.AreEqual(StatusCodes.Status204NoContent, actual: noContentResult.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task PostVisitor_Returns500InternalServerError_WhenExceptionIsThrown()
+        {
+            // Arrange
+            var visitorCreateDto = new VisitorCreateDTO();
+
+            _mockMapper.Setup(m => m.Map<Visitor>(visitorCreateDto)).Throws(new Exception());
+
+            var controller = new VisitorController(_mockVisitorRepository.Object, _mockMapper.Object);
+
+            // Act
+            var result = await controller.PostVisitor(visitorCreateDto);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(ObjectResult));
+            var objectResult = result.Result as ObjectResult;
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, actual: objectResult.StatusCode);
+            Assert.AreEqual("Error retrieving data from the database", objectResult.Value);
+        }
+    }
+}

--- a/BioscoopSysteemAPI/Tests/Tests.csproj
+++ b/BioscoopSysteemAPI/Tests/Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BioscoopSysteemApi.Models\BioscoopSysteemApi.Models.csproj" />
+    <ProjectReference Include="..\BioscoopSysteemAPI\BioscoopSysteemAPI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BioscoopSysteemAPI/Tests/Usings.cs
+++ b/BioscoopSysteemAPI/Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/BioscoopSysteemWeb/BioscoopSysteemWeb.sln
+++ b/BioscoopSysteemWeb/BioscoopSysteemWeb.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BioscoopSysteemAPI", "..\Bi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BioscoopSysteemApi.Models", "..\BioscoopSysteemAPI\BioscoopSysteemApi.Models\BioscoopSysteemApi.Models.csproj", "{21297D7F-B90B-47E2-955A-2760A4D28AD5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "..\BioscoopSysteemAPI\Tests\Tests.csproj", "{42CC1C27-905A-46DE-983B-B791FED76801}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{21297D7F-B90B-47E2-955A-2760A4D28AD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21297D7F-B90B-47E2-955A-2760A4D28AD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21297D7F-B90B-47E2-955A-2760A4D28AD5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42CC1C27-905A-46DE-983B-B791FED76801}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42CC1C27-905A-46DE-983B-B791FED76801}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42CC1C27-905A-46DE-983B-B791FED76801}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42CC1C27-905A-46DE-983B-B791FED76801}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Deel van de testen geschreven en getest. Bij reservation controller moest ik voor de lijst reservations moest ik hem hernoemen getReservations inplaats van getReservation anders kreeg ik conflicten in de testen wanneer ik by id bedoelde of een lijst van reservations bedoelde met een test.